### PR TITLE
Remove Di container. Replace with ServiceManager. Update compatibility to ZF 2.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+composer.lock
+.project
+vendor
+.htaccess

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,6 @@
     "require": {
         "php": ">=5.3.0",
         "soliantconsulting/simplefm": "dev-master",
-        "zendframework/zendframework": "2.0.1"
+        "zendframework/zendframework": "2.1.1"
     }
 }

--- a/config/autoload/local.php.dist
+++ b/config/autoload/local.php.dist
@@ -12,18 +12,10 @@
  */
 
 return array(
-    'di' => array(
-        'instance' => array(
-            'simple_fm' => array(
-                'parameters' => array(
-                    'hostParams' => array(
-                        'hostname' => 'localhost',
-                        'dbname'   => 'FMServer_Sample_Web',
-                        'username' => 'Admin',
-                        'password' => ''
-                    ),
-                ),
-            ),
-        ),
+    'simple_fm_host_params' => array(
+        'hostname' => 'localhost',
+        'dbname'   => 'FMServer_Sample_Web',
+        'username' => 'Admin',
+        'password' => ''
     ),
 );

--- a/module/Application/Module.php
+++ b/module/Application/Module.php
@@ -32,4 +32,40 @@ class Module
             ),
         );
     }
+    
+    public function getServiceConfig()
+    {
+        /**
+         * Implementing the getServiceConfig method in your Module.php is an alternative to defining
+         * a 'service_manager' node in your module.config.php. It is a matter of preference where you define
+         * your ServiceManager classes. They both achieve the same goal of injecting dependencies so you can
+         * retrieve composed classes by name from the ServiceManager. Below is an example of composing SimpleFM
+         * classes using this technique. Notice the use of a closure here for the adapter instead of a factory
+         * in the module.config.php. Use of the factory requires use of the hardcoded config name
+         */
+        return array(
+            'factories' => array(
+                'alternate_simple_fm' => function ($sm) {
+                    $config = $sm->get('config');
+                    $hostParams = $config['simple_fm_host_params'];
+                    $dbAdapter = new \Soliant\SimpleFM\Adapter($hostParams);
+                    return $dbAdapter;
+                },
+                'alternate_gateway_project' => function ($sm) {
+                    $entity = new \Application\Entity\Project();
+                    $simpleFMAdapter = $sm->get('alternate_simple_fm');
+                    $layoutnamePointer = 'ProjectPointer';
+                    $layoutname = 'Project';
+                    return new \Application\Gateway\Project($sm, $entity, $simpleFMAdapter, $layoutnamePointer, $layoutname);
+                },
+                'alternate_gateway_task' => function ($sm) {
+                    $entity = new \Application\Entity\Task();
+                    $simpleFMAdapter = $sm->get('alternate_simple_fm');
+                    $layoutnamePointer = 'TaskPointer';
+                    $layoutname = 'Task';
+                    return new \Application\Gateway\Task($sm, $entity, $simpleFMAdapter, $layoutnamePointer, $layoutname);
+                },
+            ),
+        );
+    }
 }

--- a/module/Application/config/module.config.php
+++ b/module/Application/config/module.config.php
@@ -49,48 +49,6 @@ return array(
             ),
         ),
     ),
-    'di' => array(
-        'instance' => array(
-            'alias' => array(
-                'simple_fm' => 'Soliant\SimpleFM\Adapter',
-                
-                'gateway_project' => 'Application\Gateway\Project',
-                'gateway_task' => 'Application\Gateway\Task',
-            ),
-            // simple_fm parameters included in module.config.php as a reference,
-            // but will be overridden if you create environment-specific parameters
-            // (for example: in /config/autoload/local.php or any autoload config)
-            // in which you define simple_fm parameters in this format.
-            'simple_fm' => array(
-                'parameters' => array(
-                    'hostParams' => array(
-                        'hostname' => 'localhost',
-                        'dbname'   => 'FMServer_Sample_Web',
-                        'username' => 'Admin',
-                        'password' => ''
-                    ),
-                ),
-            ),
-            'gateway_project' => array(
-                'parameters' => array(
-                    'serviceManager' => 'Zend\ServiceManager\ServiceManager',
-                    'entity' => 'Application\Entity\Project',
-                    'simpleFMAdapter' => 'simple_fm',
-                    'layoutnamePointer' => 'ProjectPointer',
-                    'layoutname' => 'Project'
-                ),
-            ),
-            'gateway_task' => array(
-                'parameters' => array(
-                    'serviceManager' => 'Zend\ServiceManager\ServiceManager',
-                    'entity' => 'Application\Entity\Task',
-                    'simpleFMAdapter' => 'simple_fm',
-                    'layoutnamePointer' => 'TaskPointer',
-                    'layoutname' => 'Task',
-                ),
-            ),
-        ),
-    ),
     'controllers' => array(
         'invokables' => array(
             'Application\Controller\Index' => 'Application\Controller\IndexController',
@@ -113,5 +71,100 @@ return array(
         'template_path_stack' => array(
             __DIR__ . '/../view',
         ),
+    ),
+    'service_manager' => array(
+        /**
+         * Notes on ServiceManager config from http://akrabat.com/zend-framework-2/zendservicemanager-configuration-keys/
+         * Within the service_manager array, there are a set of nested arrays which are generally used to configure 
+         * how you want a given class to be instantiated. the names of these sub-arrays are hardcoded, so you just 
+         * need to learn their names and the difference between them:
+         */
+            'factories' => array(
+                /** 
+                 * The factories node defines callbacks that return an instantiated class. This is for cases where you need
+                 * to configure the instance of the object. The callback can be a class that implements
+                 * Zend\ServiceManager\FactoryInterface as in the first example for the simple_fm adapter below, or
+                 * it can be a closure like the gateway factories below. Note that factories can alternately be
+                 * defined in a special getServiceConfig method which can be defined in Module.php. This module
+                 * has an example you can look at.
+                 */
+                    'simple_fm' => 'Soliant\SimpleFM\ZF2\AdapterServiceFactory',
+                    'gateway_project' => function ($sm) {
+                        $entity = new \Application\Entity\Project();
+                        $simpleFMAdapter = $sm->get('simple_fm');
+                        $layoutnamePointer = 'ProjectPointer';
+                        $layoutname = 'Project';
+                        return new \Application\Gateway\Project($sm, $entity, $simpleFMAdapter, $layoutnamePointer, $layoutname);
+                    },
+                    'gateway_task' => function ($sm) {
+                        $entity = new \Application\Entity\Task();
+                        $simpleFMAdapter = $sm->get('simple_fm');
+                        $layoutnamePointer = 'TaskPointer';
+                        $layoutname = 'Task';
+                        return new \Application\Gateway\Task($sm, $entity, $simpleFMAdapter, $layoutnamePointer, $layoutname);
+                    },
+                    
+                    
+            ),
+            'invokables' => array(
+//                 /** 
+//                  * A string which is the name of a class to be instantiated. The ServiceManager will instantiate the 
+//                  * class for you when needed.
+//                  * For example:
+//                  */
+//                     // example 1
+//                     'session' => 'Zend\Session\Storage\SessionStorage',
+//                     // example 2
+//                     'zfcuser_user' => 'User\Service\User'
+            ),
+            'services' => array(
+//                 /** 
+//                  * An instance of a class. This is used to register already instantiated objects with the ServiceManager. 
+//                  * For example:
+//                  */
+//                     'rob' => $rob,  // $rob is already instantiated
+            ),
+            'aliases' => array(
+//                 /**
+//                  * Another name for a class. Generally, you see this used within a module so that the module uses it's 
+//                  * own alias name and then the user of the module can configure exactly which class that alias name is 
+//                  * to be.
+//                  * For example:
+//                  */
+//                     // example 1
+//                     'mymodule_zend_db_adapter' => 'Zend\Db\Adapter\Adapter',
+            ),
+            'initializers' => array(
+//                 /** 
+//                  * A callback that is executed every time the ServiceManager creates a new instance of a class. These are
+//                  * usually used to inject an object into the new class instance if that class implements a particular 
+//                  * interface.
+//                  * For example:
+//                  */
+//                     function ($instance, $sm) {
+//                         if ($instance instanceof AuthorizeAwareInterface) {
+//                             $instance->setAuthorizeService($sm->get('auth_service'));
+//                         }
+//                     }
+//                     /**
+//                      * In the case, the initialiser checks if $instance implements AuthorizeAwareInterface and if it injects 
+//                      * the Authorize service into the instance ready for use. Another really common use-case is injecting a 
+//                      * database adapter and Zend Framework supplies Zend\Db\Adapter\AdapterAwareInterface for this case.
+//                      */
+            ),
+            'abstract_factories' => array(
+//                 /**
+//                  * There is also the abstract_factories key, but this is rarely used in most apps.
+//                  * 
+//                  * A factory instance that can create multiple services based on the name supplied to the factory. This is 
+//                  * used to enable ServiceManager to fallback to another Service Locator system if it can cannot locate the 
+//                  * required class from within its own configuration. As an example, you could write an abstract factory 
+//                  * that proxies to Symfony's DependencyInjection component. Items within this sub-key can be either a 
+//                  * classname string or an instance of the factory itself 
+//                  * All abstract factories must implement Zend\ServiceManager\AbstractFactoryInterface.
+//                  * For example:
+//                  */
+//                     new DiStrictAbstractServiceFactory(),
+            ),
     ),
 );


### PR DESCRIPTION
Remove direct use of Di container. Replace with ServiceManager. Update compatibility with ZF 2.1.1. Also adds some notes on ServiceManager configuration from http://akrabat.com/zend-framework-2/zendservicemanager-configuration-keys/
